### PR TITLE
OmniAuth 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rbc
 .bundle
 .config
+.ruby-version
 .yardoc
 Gemfile.lock
 InstalledFiles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 2.0.0 (Unreleased)
+
+- Breaking Changes
+  - Requires [OmniAuth 2](https://github.com/omniauth/omniauth/releases/tag/v2.0.0)
+
+## Older releases
+
+PRs welcome, in the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
+format.

--- a/lib/omniauth/strategies/your_membership_token.rb
+++ b/lib/omniauth/strategies/your_membership_token.rb
@@ -6,6 +6,13 @@ module OmniAuth
     class YourMembershipToken
       include OmniAuth::Strategy
 
+      E_YM_SESSION_ID_BLANK = <<~EOS
+        Assertion failed: YourMembership ID blank during callback_phase. This ID
+        was stored in the Rack session during the request_phase but has not
+        survived to (is no longer present in) the callback_phase.
+      EOS
+      RACK_SESSION_KEY = 'omniauth_ym_session_id'.freeze
+
       # The UID is going to be the member's API id (member_id)
       # We'll also store the session ID
       option :fields, [:member_id, :ym_session]
@@ -13,26 +20,37 @@ module OmniAuth
 
       def request_phase
 
-        # We're doing this because the callback_url is built from the options.name attribute which is built by downcasing
-        # the name of the class. This returns an uncapitalized url which Rails will not recognize as the same path as the
-        # devise controller. This is a forced way to do this and probably has a more elegant solution.
+        # We're doing this because the callback_url is built from the
+        # options.name attribute which is built by down-casing the name of the
+        # class. This returns an un-capitalized url which Rails will not
+        # recognize as the same path as the devise controller. This is a forced
+        # way to do this and probably has a more elegant solution.
         options.name = 'yourMembershipToken'
         # Build an Access Token
         session = YourMembership::Session.create
-        #binding.pry
         token_hash = session.createToken(:RetUrl => callback_url)
 
-        # Pass the YourMembership session id to the Callback
-        request.params['ym_session'] = session.to_s
+        # Store the YourMembership session id somewhere it can be retrieved
+        # during the callback_phase.
+        #
+        # In OmniAuth 1, we were able to do:
+        #
+        #     request.params['ym_session'] = session.to_s
+        #
+        # but this seems no longer possible in OmniAuth 2 (as described in
+        # https://github.com/omniauth/omniauth/issues/975). So, the only thing I
+        # can think of is to use `env['rack.session']`. If a better solution
+        # is discovered, we can revisit this decision.
+        env['rack.session'][RACK_SESSION_KEY] = session.to_s
+
         # Redirect to token url
         redirect token_hash['GoToUrl']
       end
 
+      # See discussion in `request_phase` re: the use of `env['rack.session']`.
       def callback_phase
-        # create session object
-
-        ym_session_id = request.env['omniauth.params']['ym_session']
-
+        ym_session_id = env['rack.session'][RACK_SESSION_KEY]
+        fail!(E_YM_SESSION_ID_BLANK) if ym_session_id.blank?
         ym_session  = YourMembership::Session.new(ym_session_id, 100)
 
         begin

--- a/lib/omniauth/your_membership_token/version.rb
+++ b/lib/omniauth/your_membership_token/version.rb
@@ -1,5 +1,11 @@
 module OmniAuth
   module YourMembershipToken
-    VERSION = "1.1.0"
+    def self.gem_version
+      Gem::Version.new('2.0.0')
+    end
+
+    # @deprecated But will never be removed. Use `gem_version` instead, which
+    # provides a `Gem::Version` object that is easier to work with.
+    VERSION = gem_version.to_s
   end
 end

--- a/omniauth-your-membership-token.gemspec
+++ b/omniauth-your-membership-token.gemspec
@@ -5,7 +5,7 @@ require 'omniauth/your_membership_token/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "omniauth-your-membership-token"
-  spec.version       = OmniAuth::YourMembershipToken::VERSION
+  spec.version       = OmniAuth::YourMembershipToken.gem_version.to_s
   spec.authors       = ["Nate Flood"]
   spec.email         = ["nflood@echonet.org"]
   spec.summary       = %q{Omniauth Strategy For Authenticating To YourMembership}

--- a/omniauth-your-membership-token.gemspec
+++ b/omniauth-your-membership-token.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "omniauth", "~> 1.2"
+  spec.add_dependency "omniauth", "~> 2"
   spec.add_dependency "your_membership", "~> 1.1"
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
This is a draft PR, to get the conversation started.

> OmniAuth now defaults to only POST as the allowed request_phase method.
> https://github.com/omniauth/omniauth/releases/tag/v2.0.0

Based on my reading of https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284 , this change affects applications, not this gem.